### PR TITLE
Splits out Slack message formatter

### DIFF
--- a/src/Narochno.Serilog.Slack/Formatting/AttachmentsSlackFormatter.cs
+++ b/src/Narochno.Serilog.Slack/Formatting/AttachmentsSlackFormatter.cs
@@ -1,28 +1,23 @@
-﻿using Serilog.Sinks.PeriodicBatching;
+﻿using Narochno.Slack.Entities;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using Serilog.Events;
-using System;
-using Narochno.Slack;
-using Narochno.Slack.Entities;
-using System.Linq;
-using Serilog.Parsing;
 using System.Text;
+using Serilog.Parsing;
+using System.Linq;
 
-namespace Narochno.Serilog.Slack
+namespace Narochno.Serilog.Slack.Formatting
 {
-    public class SlackBatchingSink : PeriodicBatchingSink
+    /// <summary>
+    /// Formats each log message as an attachment.
+    /// </summary>
+    public class AttachmentsSlackFormatter : ISlackFormatter
     {
-        private readonly ISlackClient slackClient;
-
-        public SlackBatchingSink(ISlackClient slackClient) : base(25, TimeSpan.FromSeconds(1))
+        public Message CreateMessage(IEnumerable<LogEvent> events)
         {
-            this.slackClient = slackClient;
-        }
-
-        protected override async Task EmitBatchAsync(IEnumerable<LogEvent> events)
-        {
-            var result = await slackClient.PostAttachments(GetAttachments(events));
+            return new Message
+            {
+                Attachments = GetAttachments(events)
+            };
         }
 
         protected IEnumerable<Attachment> GetAttachments(IEnumerable<LogEvent> events)
@@ -124,12 +119,6 @@ namespace Narochno.Serilog.Slack
                 default:
                     return "good";
             }
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            slackClient.Dispose();
-            base.Dispose(disposing);
         }
     }
 }

--- a/src/Narochno.Serilog.Slack/Formatting/ISlackFormatter.cs
+++ b/src/Narochno.Serilog.Slack/Formatting/ISlackFormatter.cs
@@ -1,0 +1,11 @@
+﻿using Narochno.Slack.Entities;
+using Serilog.Events;
+using System.Collections.Generic;
+
+namespace Narochno.Serilog.Slack.Formatting
+{
+    public interface ISlackFormatter
+    {
+        Message CreateMessage(IEnumerable<LogEvent> logEvents);
+    }
+}

--- a/src/Narochno.Serilog.Slack/LoggerConfigurationExtensions.cs
+++ b/src/Narochno.Serilog.Slack/LoggerConfigurationExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Narochno.Slack;
+﻿using Narochno.Serilog.Slack.Formatting;
+using Narochno.Slack;
 using Serilog;
 using Serilog.Configuration;
 using Serilog.Events;
@@ -21,7 +22,8 @@ namespace Narochno.Serilog.Slack
             }
 
             var slackClient = new SlackClient(slackConfig);
-            var batchingSink = new SlackBatchingSink(slackClient);
+            var messageFormatter = new AttachmentsSlackFormatter();
+            var batchingSink = new SlackBatchingSink(slackClient, messageFormatter);
             return loggerConfiguration.Sink(batchingSink, minimumLevel);
         }
     }

--- a/src/Narochno.Serilog.Slack/SlackBatchingSink.cs
+++ b/src/Narochno.Serilog.Slack/SlackBatchingSink.cs
@@ -1,0 +1,34 @@
+﻿using Serilog.Sinks.PeriodicBatching;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Serilog.Events;
+using System;
+using Narochno.Slack;
+using Narochno.Serilog.Slack.Formatting;
+
+namespace Narochno.Serilog.Slack
+{
+    public class SlackBatchingSink : PeriodicBatchingSink
+    {
+        private readonly ISlackClient slackClient;
+        private readonly ISlackFormatter messageFormatter;
+
+        public SlackBatchingSink(ISlackClient slackClient, ISlackFormatter messageFormatter)
+            : base(25, TimeSpan.FromSeconds(1))
+        {
+            this.slackClient = slackClient;
+            this.messageFormatter = messageFormatter;
+        }
+
+        protected override async Task EmitBatchAsync(IEnumerable<LogEvent> events)
+        {
+            await slackClient.PostMessage(messageFormatter.CreateMessage(events));
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            slackClient.Dispose();
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/Narochno.Serilog.Slack/project.json
+++ b/src/Narochno.Serilog.Slack/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.4",
+  "version": "1.1.0",
 
   "dependencies": {
     "Narochno.Slack": "1.4.2",

--- a/test/Narochno.Serilog.Slack.Tester/project.json
+++ b/test/Narochno.Serilog.Slack.Tester/project.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "version": "1.0.0-*",
   "buildOptions": {
     "emitEntryPoint": true
@@ -14,7 +14,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.1"
+          "version": "1.1.0"
         }
       }
     }


### PR DESCRIPTION
Allows for greater customisation - package consumers can implement `ISlackFormatter` in their own class to gain finer control over how Slack messages are formatted. Moves existing formatting code to `AttachmentsSlackFormatter`. Bumps version.