### PR TITLE
Adds discord support via the AttachmentsSlackFormatter

### DIFF
--- a/src/Narochno.Serilog.Slack/Formatting/AttachmentsSlackFormatter.cs
+++ b/src/Narochno.Serilog.Slack/Formatting/AttachmentsSlackFormatter.cs
@@ -1,9 +1,6 @@
 ﻿using Narochno.Slack.Entities;
-using System.Collections.Generic;
 using Serilog.Events;
-using System.Text;
-using Serilog.Parsing;
-using System.Linq;
+using System.Collections.Generic;
 
 namespace Narochno.Serilog.Slack.Formatting
 {
@@ -27,98 +24,11 @@ namespace Narochno.Serilog.Slack.Formatting
                 yield return new Attachment
                 {
                     Timestamp = ev.Timestamp.ToUnixTimeSeconds(),
-                    Color = GetColor(ev.Level),
-                    MrkdwnIn = new[] { "fields" },
-                    Fields = GetFields(ev),
+                    Color = ev.Level.GetColor(),
+                    Text = ev.RenderMessage(null),
                     Fallback = $"[{ev.Level}] {ev.RenderMessage(null)}",
-                    Footer = $"{GetEmoji(ev.Level)} {ev.Level}"
+                    Footer = $"{ev.Level.GetEmoji()} {ev.Level}"
                 };
-            }
-        }
-
-        protected string GetPropertyValue(LogEventPropertyValue value)
-        {
-            var scalar = value as ScalarValue;
-            if (scalar?.Value != null)
-            {
-                return scalar.Value.ToString();
-            }
-
-            return value.ToString();
-        }
-
-        protected string GetMessage(LogEvent logEvent)
-        {
-            var messageBuilder = new StringBuilder();
-            foreach (var messageToken in logEvent.MessageTemplate.Tokens)
-            {
-                var messagePropertyToken = messageToken as PropertyToken;
-                if (messagePropertyToken != null)
-                {
-                    var property = logEvent.Properties[messagePropertyToken.PropertyName];
-                    messageBuilder.AppendFormat("`{0}`", GetPropertyValue(property));
-                }
-                else
-                {
-                    messageBuilder.Append(messageToken.ToString());
-                }
-            }
-            return messageBuilder.ToString();
-        }
-
-        protected IEnumerable<Field> GetFields(LogEvent logEvent)
-        {
-            yield return new Field { Value = GetMessage(logEvent) };
-
-            var propertyTokens = logEvent.MessageTemplate.Tokens.OfType<PropertyToken>().Select(x => x.PropertyName);
-
-            var contextProperties = logEvent.Properties.Where(p => !p.Key.All(char.IsNumber) && !propertyTokens.Contains(p.Key));
-            foreach (var property in contextProperties)
-            {
-                yield return new Field
-                {
-                    Title = property.Key,
-                    Value = GetPropertyValue(property.Value),
-                    Short = true
-                };
-            }
-
-            if (logEvent.Exception != null)
-            {
-                yield return new Field
-                {
-                    Title = logEvent.Exception.GetType().FullName,
-                    Value = $"```{logEvent.Exception}```",
-                    Short = false
-                };
-            }
-        }
-
-        protected string GetEmoji(LogEventLevel level)
-        {
-            switch (level)
-            {
-                case LogEventLevel.Error:
-                    return ":exclamation:";
-                case LogEventLevel.Warning:
-                    return ":warning:";
-                case LogEventLevel.Fatal:
-                    return ":x:";
-                default:
-                    return null;
-            }
-        }
-
-        protected string GetColor(LogEventLevel level)
-        {
-            switch (level)
-            {
-                case LogEventLevel.Error:
-                    return "danger";
-                case LogEventLevel.Warning:
-                    return "warning";
-                default:
-                    return "good";
             }
         }
     }

--- a/src/Narochno.Serilog.Slack/Formatting/FieldsSlackFormatter.cs
+++ b/src/Narochno.Serilog.Slack/Formatting/FieldsSlackFormatter.cs
@@ -1,0 +1,97 @@
+﻿using Narochno.Slack.Entities;
+using System.Collections.Generic;
+using Serilog.Events;
+using System.Text;
+using Serilog.Parsing;
+using System.Linq;
+
+namespace Narochno.Serilog.Slack.Formatting
+{
+    /// <summary>
+    /// Formats each log message as an attachment with fields.
+    /// </summary>
+    public class FieldsSlackFormatter : ISlackFormatter
+    {
+        public Message CreateMessage(IEnumerable<LogEvent> events)
+        {
+            return new Message
+            {
+                Attachments = GetAttachments(events)
+            };
+        }
+
+        protected IEnumerable<Attachment> GetAttachments(IEnumerable<LogEvent> events)
+        {
+            foreach (var ev in events)
+            {
+                yield return new Attachment
+                {
+                    Timestamp = ev.Timestamp.ToUnixTimeSeconds(),
+                    Color = ev.Level.GetColor(),
+                    MrkdwnIn = new[] { "fields" },
+                    Fields = GetFields(ev),
+                    Fallback = $"[{ev.Level}] {ev.RenderMessage(null)}",
+                    Footer = $"{ev.Level.GetEmoji()} {ev.Level}"
+                };
+            }
+        }
+
+        protected string GetPropertyValue(LogEventPropertyValue value)
+        {
+            var scalar = value as ScalarValue;
+            if (scalar?.Value != null)
+            {
+                return scalar.Value.ToString();
+            }
+
+            return value.ToString();
+        }
+
+        protected string GetMessage(LogEvent logEvent)
+        {
+            var messageBuilder = new StringBuilder();
+            foreach (var messageToken in logEvent.MessageTemplate.Tokens)
+            {
+                var messagePropertyToken = messageToken as PropertyToken;
+                if (messagePropertyToken != null)
+                {
+                    var property = logEvent.Properties[messagePropertyToken.PropertyName];
+                    messageBuilder.AppendFormat("`{0}`", GetPropertyValue(property));
+                }
+                else
+                {
+                    messageBuilder.Append(messageToken.ToString());
+                }
+            }
+            return messageBuilder.ToString();
+        }
+
+        protected IEnumerable<Field> GetFields(LogEvent logEvent)
+        {
+            yield return new Field { Value = GetMessage(logEvent) };
+
+            var propertyTokens = logEvent.MessageTemplate.Tokens.OfType<PropertyToken>().Select(x => x.PropertyName);
+
+            var contextProperties = logEvent.Properties.Where(p => !p.Key.All(char.IsNumber) && !propertyTokens.Contains(p.Key));
+            foreach (var property in contextProperties)
+            {
+                yield return new Field
+                {
+                    Title = property.Key,
+                    Value = GetPropertyValue(property.Value),
+                    Short = true
+                };
+            }
+
+            if (logEvent.Exception != null)
+            {
+                yield return new Field
+                {
+                    Title = logEvent.Exception.GetType().FullName,
+                    Value = $"```{logEvent.Exception}```",
+                    Short = false
+                };
+            }
+        }
+    }
+}

--- a/src/Narochno.Serilog.Slack/Formatting/LogEventLevelExtensions.cs
+++ b/src/Narochno.Serilog.Slack/Formatting/LogEventLevelExtensions.cs
@@ -1,11 +1,10 @@
-﻿using Narochno.Primitives;
-using Serilog.Events;
+﻿using Serilog.Events;
 
 namespace Narochno.Serilog.Slack.Formatting
 {
     public static class LogEventLevelExtensions
     {
-        public static Optional<string> GetEmoji(this LogEventLevel level)
+        public static string GetEmoji(this LogEventLevel level)
         {
             switch (level)
             {

--- a/src/Narochno.Serilog.Slack/Formatting/LogEventLevelExtensions.cs
+++ b/src/Narochno.Serilog.Slack/Formatting/LogEventLevelExtensions.cs
@@ -1,0 +1,36 @@
+﻿using Narochno.Primitives;
+using Serilog.Events;
+
+namespace Narochno.Serilog.Slack.Formatting
+{
+    public static class LogEventLevelExtensions
+    {
+        public static Optional<string> GetEmoji(this LogEventLevel level)
+        {
+            switch (level)
+            {
+                case LogEventLevel.Error:
+                    return ":exclamation:";
+                case LogEventLevel.Warning:
+                    return ":warning:";
+                case LogEventLevel.Fatal:
+                    return ":x:";
+                default:
+                    return null;
+            }
+        }
+
+        public static string GetColor(this LogEventLevel level)
+        {
+            switch (level)
+            {
+                case LogEventLevel.Error:
+                    return "danger";
+                case LogEventLevel.Warning:
+                    return "warning";
+                default:
+                    return "good";
+            }
+        }
+    }
+}

--- a/src/Narochno.Serilog.Slack/LoggerConfigurationExtensions.cs
+++ b/src/Narochno.Serilog.Slack/LoggerConfigurationExtensions.cs
@@ -22,7 +22,29 @@ namespace Narochno.Serilog.Slack
             }
 
             var slackClient = new SlackClient(slackConfig);
-            var messageFormatter = new AttachmentsSlackFormatter();
+            var messageFormatter = new FieldsSlackFormatter();
+            var batchingSink = new SlackBatchingSink(slackClient, messageFormatter);
+            return loggerConfiguration.Sink(batchingSink, minimumLevel);
+        }
+
+        public static LoggerConfiguration Slack(this LoggerSinkConfiguration loggerConfiguration, SlackConfig slackConfig, ISlackFormatter messageFormatter, LogEventLevel minimumLevel = LevelAlias.Minimum)
+        {
+            if (loggerConfiguration == null)
+            {
+                throw new ArgumentNullException(nameof(loggerConfiguration));
+            }
+
+            if (slackConfig == null)
+            {
+                throw new ArgumentNullException(nameof(slackConfig));
+            }
+
+            if (messageFormatter == null)
+            {
+                throw new ArgumentNullException(nameof(messageFormatter));
+            }
+
+            var slackClient = new SlackClient(slackConfig);
             var batchingSink = new SlackBatchingSink(slackClient, messageFormatter);
             return loggerConfiguration.Sink(batchingSink, minimumLevel);
         }

--- a/src/Narochno.Serilog.Slack/SlackBatchingSink.cs
+++ b/src/Narochno.Serilog.Slack/SlackBatchingSink.cs
@@ -5,8 +5,6 @@ using Serilog.Events;
 using System;
 using Narochno.Slack;
 using Narochno.Serilog.Slack.Formatting;
-using Serilog.Debugging;
-using Narochno.Slack.Entities;
 
 namespace Narochno.Serilog.Slack
 {
@@ -24,11 +22,7 @@ namespace Narochno.Serilog.Slack
 
         protected override async Task EmitBatchAsync(IEnumerable<LogEvent> events)
         {
-            var result = await slackClient.PostMessage(messageFormatter.CreateMessage(events));
-            if (result != SlackCode.Ok)
-            {
-                SelfLog.WriteLine("Got error response from Slack: {0}", result);
-            }
+            await slackClient.PostMessage(messageFormatter.CreateMessage(events));
         }
 
         protected override void Dispose(bool disposing)

--- a/src/Narochno.Serilog.Slack/project.json
+++ b/src/Narochno.Serilog.Slack/project.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.2.0",
+    "version": "1.3.0",
     "authors": [ "alanedwardes", "adamhathcock" ],
 
     "packOptions": {
@@ -8,7 +8,7 @@
     },
 
     "dependencies": {
-        "Narochno.Slack": "1.6.0",
+        "Narochno.Slack": "2.0.0",
         "Serilog.Sinks.PeriodicBatching": "2.1.0"
     },
 

--- a/test/Narochno.Serilog.Slack.Tester/Program.cs
+++ b/test/Narochno.Serilog.Slack.Tester/Program.cs
@@ -1,4 +1,5 @@
-﻿using Narochno.Slack;
+﻿using Narochno.Serilog.Slack.Formatting;
+using Narochno.Slack;
 using Serilog;
 using Serilog.Context;
 using System;
@@ -12,7 +13,8 @@ namespace Narochno.Serilog.Slack.Tester
             var webHookUrl = "your webhook URL";
 
             Log.Logger = new LoggerConfiguration()
-                .WriteTo.Slack(new SlackConfig { WebHookUrl = webHookUrl })
+                //.WriteTo.Slack(new SlackConfig { WebHookUrl = webHookUrl })
+                .WriteTo.Slack(new SlackConfig { WebHookUrl = webHookUrl }, new AttachmentsSlackFormatter())
                 .WriteTo.Console()
                 .Enrich.FromLogContext()
                 .CreateLogger();


### PR DESCRIPTION
Adds a new stripped down formatter for Slack and the Discord compatible webhook.

### Slack Sample
![image](https://cloud.githubusercontent.com/assets/110954/21957319/b7826102-da8b-11e6-81af-9c89f98753f7.png)

### Discord Sample
![image](https://cloud.githubusercontent.com/assets/110954/21957370/75808dfa-da8c-11e6-962c-654488071b85.png)

There appears to be a bug in Discord which means that emoji included in the footer are ignored - this is a Discord bug, as the API is meant to be Slack compatible, so I won't work around that.