### PR TITLE
Added color for fatal messages

### DIFF
--- a/src/Narochno.Serilog.Slack/Formatting/LogEventLevelExtensions.cs
+++ b/src/Narochno.Serilog.Slack/Formatting/LogEventLevelExtensions.cs
@@ -27,6 +27,8 @@ namespace Narochno.Serilog.Slack.Formatting
                     return "danger";
                 case LogEventLevel.Warning:
                     return "warning";
+                case LogEventLevel.Fatal:
+                    return "danger";
                 default:
                     return "good";
             }

--- a/src/Narochno.Serilog.Slack/Narochno.Serilog.Slack.csproj
+++ b/src/Narochno.Serilog.Slack/Narochno.Serilog.Slack.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>A batching Serilog sink for Slack. Each log message is sent as an attachment on the same message, with the log event properties rendered out as fields.</Description>
-    <Version>3.0.0</Version>
+    <Version>3.0.1</Version>
     <Authors>alanedwardes;adamhathcock</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Narochno.Serilog.Slack</AssemblyName>


### PR DESCRIPTION
I was using this and realized fatal logs were sending good bar in slack messages. It's a small fix for that. Please push and deploy it to nuget :) 